### PR TITLE
fix: Settings modal unusable

### DIFF
--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -224,7 +224,7 @@ Settings include backend URL, theme, refresh interval, and advanced options.
 		align-items: center;
 		justify-content: center;
 		z-index: 1000;
-		overflow: auto;
+		overflow: hidden;
 		transform: translateZ(0);
 	}
 


### PR DESCRIPTION
## Summary

Fix modal positioning and button responsiveness by changing overlay overflow from auto to hidden, ensuring modal is fully visible within viewport and click events are not intercepted.

## Changes

- Changed `.modal-overlay` CSS `overflow: auto` to `overflow: hidden`
- Prevents scrollbars from interfering with flex centering
- Ensures modal is not cut off at top of viewport
- Buttons are now clickable as overlay does not scroll

## Testing

- Manual testing: open settings modal, verify it appears centered and fully visible
- Buttons (Save, Cancel, Reset, Close) respond to clicks
- Modal closes correctly when clicking overlay or close button

Fixes LostDakota/orchestratorr#3